### PR TITLE
Update URL and descriptions leftover from earlier HipChat gem base.

### DIFF
--- a/eye-slack.gemspec
+++ b/eye-slack.gemspec
@@ -8,9 +8,9 @@ Gem::Specification.new do |spec|
   spec.version       = Eye::Notify::Slack::VERSION
   spec.authors       = ["Tom Meinlschmidt"]
   spec.email         = ["tomas@meinlschmidt.org"]
-  spec.summary       = %q{Eye to hipchat notification}
-  spec.description   = %q{Eye to hipchat notification}
-  spec.homepage      = "https://github.com/tmeinlschmidt/eye-hipchat"
+  spec.summary       = %q{Eye to Slack notification}
+  spec.description   = %q{Eye to Slack notification}
+  spec.homepage      = "https://github.com/tmeinlschmidt/eye-slack"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")


### PR DESCRIPTION
The [page on rubygems](https://rubygems.org/gems/eye-slack) is rather confusing with the leftover URLs, links and descriptions.
